### PR TITLE
Updated Service Provider to use static factory() method because of errors being thrown by Guzzle when trying to instantiate

### DIFF
--- a/src/KeenLaravelServiceProvider.php
+++ b/src/KeenLaravelServiceProvider.php
@@ -37,12 +37,12 @@ class KeenLaravelServiceProvider extends ServiceProvider
 
             $config = $app['config']['keen'];
 
-            return (new KeenIOClient())->factory([
+            return (KeenIOClient::factory([
                 'projectId' => $config['projectId'],
                 'masterKey' => $config['masterKey'],
                 'writeKey'  => $config['writeKey'],
                 'readKey'   => $config['readKey']
-            ]);
+            ]));
         });
     }
 


### PR DESCRIPTION
Updated Service Provider to use static factory() method because of errors being thrown by Guzzle when trying to instantiate