### PR TITLE
fix: update keen version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "illuminate/support": "5.*",
-    "keen-io/keen-io": "~2.5"
+    "keen-io/keen-io": "2.6.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Hey Gareth ;)

Just bumping up the keen version as the previous keen.io versions depend on mcrypt, which is deprecated as of php7.2 (and also no longer secure).